### PR TITLE
command line option -mpqc3 in pt2r12 program

### DIFF
--- a/src/bin/pt2r12/extern_pt2r12.cc
+++ b/src/bin/pt2r12/extern_pt2r12.cc
@@ -55,7 +55,9 @@ ExternPT2R12::ExternPT2R12(const Ref<KeyVal>& kv) :
   std::string r12_str = kv->stringvalue("pt2_correction", KeyValValuestring(std::string()));
   std::string singles_str = kv->stringvalue("cabs_singles", KeyValValuestring(std::string()));
   std::string partition_str = kv->stringvalue("cabs_singles_h0", KeyValValuestring(std::string()));
+#if defined(HAVE_MPQC3_RUNTIME)
   std::string mpqc3_str = kv->stringvalue("use_mpqc3", KeyValValuestring(std::string()));
+#endif
 
   Ref<OrbitalSpace> orbs = orbs_info_->orbs();
   const std::vector<unsigned int>& fzcpi = orbs_info_->fzcpi();
@@ -132,8 +134,10 @@ ExternPT2R12::ExternPT2R12(const Ref<KeyVal>& kv) :
       kva->assign("cabs_singles", singles_str);
     if(!partition_str.empty())
       kva->assign("cabs_singles_h0", partition_str);
+#if defined(HAVE_MPQC3_RUNTIME)
     if(!mpqc3_str.empty())
       kva->assign("use_mpqc3", mpqc3_str);
+#endif
     if (cabs_name_.empty() == false) {
       Ref<AssignedKeyVal> tmpkv = new AssignedKeyVal;
       tmpkv->assign("name", cabs_name_.c_str());

--- a/src/bin/pt2r12/pt2r12.cc
+++ b/src/bin/pt2r12/pt2r12.cc
@@ -161,7 +161,9 @@ int try_main(int argc, char **argv)
   opt.enroll("singles", GetLongOpt::MandatoryValue, "compute [2]_s correction; default: false", 0);
   opt.enroll("partitionH", GetLongOpt::MandatoryValue, "How to partition Hamiltonian in [2]_s; default: dyall_1", 0);
   opt.enroll("verbose", GetLongOpt::NoValue, "enable extra printing", 0);
-  opt.enroll("mpqc3", GetLongOpt::MandatoryValue, "enable MPQC3 runtime features; default: false", 0);
+#if defined(HAVE_MPQC3_RUNTIME)
+  opt.enroll("mpqc3", GetLongOpt::MandatoryValue, "enable MPQC3 runtime features; default: true", 0);
+#endif
 
   // initialize the environment
   MPQCInit init(opt,argc,argv);
@@ -253,10 +255,10 @@ int try_main(int argc, char **argv)
   const std::string singles_str = singles_cstr?singles_cstr:"";
   const char* partition_cstr = opt.retrieve("partitionH");
   const std::string partition_str = partition_cstr?partition_cstr:"";
-  // determine if use MPQC3 runtime
+#if defined(HAVE_MPQC3_RUNTIME)
   const char* mpqc3_cstr = opt.retrieve("mpqc3");
   const std::string mpqc3_str = mpqc3_cstr?mpqc3_cstr:"";
-
+#endif
 
   ExEnv::out0() << indent << "Given resources: " << resources->sprint() << endl
       << endl;
@@ -408,8 +410,10 @@ int try_main(int argc, char **argv)
       kva->assign("cabs_singles", singles_str);
     if(not partition_str.empty())
       kva->assign("cabs_singles_h0", partition_str);
+#if defined(HAVE_MPQC3_RUNTIME)
     if(not mpqc3_str.empty())
       kva->assign("use_mpqc3", mpqc3_str);
+#endif
     Ref<KeyVal> kv = kva;
     extern_pt2r12 = new ExternPT2R12(kv);
   }

--- a/src/lib/chemistry/qc/mbptr12/pt2r12.cc
+++ b/src/lib/chemistry/qc/mbptr12/pt2r12.cc
@@ -68,14 +68,8 @@ PT2R12::PT2R12(const Ref<KeyVal> &keyval) : Wavefunction(keyval), B_(), X_(), V_
   cabs_singles_ = keyval->booleanvalue("cabs_singles", KeyValValueboolean(false));
   cabs_singles_h0_ = keyval->stringvalue("cabs_singles_h0", KeyValValuestring(string("dyall_1")));
   cabs_singles_coupling_ = keyval->booleanvalue("cabs_singles_coupling", KeyValValueboolean(true));
-  use_mpqc3_ = keyval->booleanvalue("use_mpqc3",KeyValValueboolean(false));
-
-//print warning if mpqc3 is asked when don't have HAVE_MPQC3_RUNTIME
-#if not defined (HAVE_MPQC3_RUNTIME)
-  if (use_mpqc3_){
-    ExEnv::out0() << std::endl << std::endl << indent
-      << "::::Warning::::\n" << indent << "MPQC3_RUNTIME not available, will use mpqc2 code.\n \n";
-  }
+#if defined(HAVE_MPQC3_RUNTIME)
+  use_mpqc3_ = keyval->booleanvalue("use_mpqc3",KeyValValueboolean(true));
 #endif
   rotate_core_ = keyval->booleanvalue("rotate_core", KeyValValueboolean(true));
 
@@ -1336,21 +1330,17 @@ void PT2R12::compute()
   {
     MPQC_ASSERT(r12world()->r12tech()->ansatz()->projector() == R12Technology::Projector_2);
 
-// #define ENABLE_NEW_PT2R12_CODE 1
 #if defined(HAVE_MPQC3_RUNTIME)
     if (use_mpqc3_) {
       std::pair<double,double> e = energy_PT2R12_projector2_mpqc3();
       energy_pt2r12_sf = e.first;
       recomp_ref_energy = e.second;
-    }
-    else {
+    } else
+#endif
+    {
       energy_pt2r12_sf = energy_PT2R12_projector2();
       recomp_ref_energy = this->energy_recomputed_from_densities();
     }
-#else
-    energy_pt2r12_sf = energy_PT2R12_projector2();
-    recomp_ref_energy = this->energy_recomputed_from_densities();
-#endif
     energy_correction_r12 = energy_pt2r12_sf;
   }
 

--- a/src/lib/chemistry/qc/mbptr12/pt2r12.h
+++ b/src/lib/chemistry/qc/mbptr12/pt2r12.h
@@ -276,7 +276,7 @@ namespace sc {
       unsigned int nfzc_;
       bool omit_uocc_;
       bool pt2_correction_;          // for testing purposes only, set to false to skip the [2]_R12 computation
-      bool cabs_singles_;           // if set to true, then use MPQC3 runtime
+      bool cabs_singles_;
       std::string cabs_singles_h0_; // specify zeroth order H; options: 'CI'
                                      // 'dyall_1', 'dyall_2', 'complete'; '1' and '2'
                                      // in dyall_sf options
@@ -284,7 +284,9 @@ namespace sc {
                                      // in H(1).
       bool cabs_singles_coupling_; // if set to true, we include the coupling between cabs and OBS virtual orbitals. This should be preferred choice,
                                    // as explained in the paper.
-      bool use_mpqc3_;
+#if defined(HAVE_MPQC3_RUNTIME)
+      bool use_mpqc3_;   // if set to true, then use MPQC3 runtime
+#endif
       bool rotate_core_; // if set to false, when doing rasscf cabs_singles correction, don't include excitation from core orbitals to cabs orbitals in
                          // first-order Hamiltonian. (this may be used when using frozen core orbitals which
                          // are not optimized (does not satisfy Brillouin condition)). Currently, we suggest set it to 'true'


### PR DESCRIPTION
add command line option -mpqc3 to pt2r12 program, it's used to control if use MPQC3 new feature, the default is false.

MPQC3 new feature in pt2r12 only works if MPQC is compiled with TA

tested with MPQC(libint) and MPQC(libint,TA)
